### PR TITLE
fix(lib): Handle nullability for reference types better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include `@deprecated` JSDoc if property is marked as `[Obsolete]` #45
+- Include `@deprecated` JSDoc if property is marked as `[Obsolete]` (#45)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include `@deprecated` JSDoc if property is marked as `[Obsolete]` #45
 
+### Fixed
+
+- Handle nullability for more types, including `string` and records (#51)
+
 ## [0.10.0] - 2024-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle nullability for more types, including `string` and records (#51)
 
+### Changed
+
+- Update xunit and friends
+- Update Microsoft.NET.Test.Sdk to 17.10.0
+
 ## [0.10.0] - 2024-04-21
 
 ### Added

--- a/TypeContractor.Tests/Helpers/TypeChecksTests.cs
+++ b/TypeContractor.Tests/Helpers/TypeChecksTests.cs
@@ -9,38 +9,44 @@ namespace TypeContractor.Tests.Helpers
     public class TypeChecksTests
     {
 #pragma warning disable CS0649
+        public string _regularString = "";
         public string? _nullableString;
         public decimal? _nullableDecimal;
         public bool? _nullableBoolean;
         internal CustomCollection? _customCollection;
         internal MyEnum _enum;
         internal MyEnum? _nullableEnum;
+        internal MyRecord? _nullableRecord;
+        internal MyRecord _regularRecordReference;
 #pragma warning restore CS0649
 
         [Theory]
         [InlineData(nameof(_nullableDecimal))]
         [InlineData(nameof(_nullableBoolean))]
         [InlineData(nameof(_nullableEnum))]
+        [InlineData(nameof(_nullableRecord))]
+        [InlineData(nameof(_nullableString))]
+        [InlineData(nameof(_customCollection))]
         public void IsNullable_Is_True_For_Nullable_Types(string fieldName)
         {
             var field = typeof(TypeChecksTests)
-                .GetField(fieldName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .GetField(fieldName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 ?? throw new ArgumentNullException(nameof(fieldName), $"Unable to find field '{fieldName}'");
 
-            TypeChecks.IsNullable(field.FieldType).Should().BeTrue();
+            TypeChecks.IsNullable(field).Should().BeTrue();
         }
 
         [Theory]
-        [InlineData(nameof(_nullableString))]
-        [InlineData(nameof(_customCollection))]
+        [InlineData(nameof(_regularString))]
         [InlineData(nameof(_enum))]
+        [InlineData(nameof(_regularRecordReference))]
         public void IsNullable_Is_False_For_Reference_Types(string fieldName)
         {
             var field = typeof(TypeChecksTests)
-                .GetField(fieldName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .GetField(fieldName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 ?? throw new ArgumentNullException(nameof(fieldName), $"Unable to find field '{fieldName}'");
 
-            TypeChecks.IsNullable(field.FieldType).Should().BeFalse();
+            TypeChecks.IsNullable(field).Should().BeFalse();
         }
 
         [Theory]
@@ -274,6 +280,8 @@ namespace TypeContractor.Tests.Helpers
         None,
         Error,
     }
+
+    internal record MyRecord(string Name);
 
     internal class CustomCollection
     {

--- a/TypeContractor.Tests/TypeScript/TypeScriptConverterTests.cs
+++ b/TypeContractor.Tests/TypeScript/TypeScriptConverterTests.cs
@@ -331,7 +331,23 @@ public class TypeScriptConverterTests
         prop.IsBuiltin.Should().BeTrue();
     }
 
+    [Fact]
+    public void Handles_Nullable_Records_Inside_Other_Records()
+    {
+        var result = Sut.Convert(typeof(TopLevelRecord));
+
+        result.Should().NotBeNull();
+        result.Properties.Should().HaveCount(2);
+
+        var second = result.Properties!.Last();
+        second.IsNullable.Should().BeTrue();
+    }
+
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    private record TopLevelRecord(string Name, SecondStoryRecord? SecondStoryRecord);
+    private record SecondStoryRecord(string Description, SomeOtherDeeplyNestedRecord? SomeOtherDeeplyNestedRecord);
+    private record SomeOtherDeeplyNestedRecord(string Extra);
+
     private class SimpleTypes
     {
         public string StringProperty { get; set; }

--- a/TypeContractor/Helpers/TypeChecks.cs
+++ b/TypeContractor/Helpers/TypeChecks.cs
@@ -4,9 +4,23 @@ namespace TypeContractor.Helpers;
 
 public static class TypeChecks
 {
+    private static readonly NullabilityInfoContext _nullabilityContext = new();
+
+    public static bool IsNullable(FieldInfo fieldInfo)
+    {
+        ArgumentNullException.ThrowIfNull(fieldInfo);
+        return IsNullable(fieldInfo.FieldType) || _nullabilityContext.Create(fieldInfo).WriteState == NullabilityState.Nullable;
+    }
+
+    public static bool IsNullable(PropertyInfo propertyInfo)
+    {
+        ArgumentNullException.ThrowIfNull(propertyInfo);
+        return IsNullable(propertyInfo.PropertyType) || _nullabilityContext.Create(propertyInfo).WriteState == NullabilityState.Nullable;
+    }
+
     public static bool IsNullable(Type sourceType)
     {
-        ArgumentNullException.ThrowIfNull(sourceType, nameof(sourceType));
+        ArgumentNullException.ThrowIfNull(sourceType);
         return Nullable.GetUnderlyingType(sourceType) != null || sourceType.Name == "Nullable`1";
     }
 

--- a/TypeContractor/TypeScript/TypeScriptConverter.cs
+++ b/TypeContractor/TypeScript/TypeScriptConverter.cs
@@ -80,7 +80,7 @@ public class TypeScriptConverter
 
             var destinationName = GetDestinationName(property.Name);
             var destinationType = GetDestinationType(property.PropertyType, property.CustomAttributes, isReadonly);
-            var outputProperty = new OutputProperty(property.Name, property.PropertyType, destinationType.InnerType, destinationName, destinationType.TypeName, destinationType.ImportType, destinationType.IsBuiltin, destinationType.IsArray, TypeChecks.IsNullable(property.PropertyType), destinationType.IsReadonly);
+            var outputProperty = new OutputProperty(property.Name, property.PropertyType, destinationType.InnerType, destinationName, destinationType.TypeName, destinationType.ImportType, destinationType.IsBuiltin, destinationType.IsArray, TypeChecks.IsNullable(property), destinationType.IsReadonly);
 
             var obsolete = property.CustomAttributes.FirstOrDefault(x => x.AttributeType.FullName == "System.ObsoleteAttribute");
             outputProperty.Obsolete = obsolete is not null ? new ObsoleteInfo((string?)obsolete.ConstructorArguments.FirstOrDefault().Value) : null;

--- a/TypeContractor/TypeScript/TypeScriptWriter.cs
+++ b/TypeContractor/TypeScript/TypeScriptWriter.cs
@@ -7,7 +7,7 @@ namespace TypeContractor.TypeScript;
 
 public class TypeScriptWriter(string outputPath)
 {
-    private readonly StringBuilder _builder = new StringBuilder();
+    private readonly StringBuilder _builder = new();
 
     public string Write(OutputType outputType, IEnumerable<OutputType> allTypes)
     {


### PR DESCRIPTION
.NET6 adds better tools for finding nullability information[1], which we now use to handle records and strings among other things. Fixes #51

[1]: https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/#libraries-reflection-apis-for-nullability-information