### PR TITLE
fix(lib): Generate correct variable reference when unpacking query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Use the correct variable reference when unpacking query parameters (Really fix #68)
+
 ## [0.12.3] - 2024-09-17
 
 ### Fixed

--- a/TypeContractor/TypeScript/ApiClientWriter.cs
+++ b/TypeContractor/TypeScript/ApiClientWriter.cs
@@ -97,7 +97,9 @@ public class ApiClientWriter(string outputPath, string? relativeRoot)
                     {
                         if (property.IsNullable)
                             _builder.AppendFormat("    if (!!{0})\r\n  ", property.DestinationName);
-                        _builder.AppendFormat("    url.searchParams.append('{0}', {0}.toString());\r\n", property.DestinationName);
+                        _builder.AppendFormat("    url.searchParams.append('{0}', {1}.toString());\r\n",
+                                              property.DestinationName,
+                                              $"{queryParam.Name}.{property.DestinationName}");
                     }
                 }
             }


### PR DESCRIPTION
Really fixes #68 this time.
The people responsible for fixing #68 the first time have been sacked.