### PR TITLE
fix(lib): Add both uppercase and lowercase HTTP verbs to api templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed
+
+- Always use uppercase HTTP verbs (#149)
+
 ## [0.17.2] - 2025-04-14
 
 ### Fixed

--- a/TypeContractor/Templates/EndpointTemplateDto.cs
+++ b/TypeContractor/Templates/EndpointTemplateDto.cs
@@ -1,10 +1,11 @@
-﻿namespace TypeContractor.Templates;
+namespace TypeContractor.Templates;
 
 public record EndpointTemplateDto(
 	string Name,
 	bool IsObsolete,
 	string ObsoleteReason,
 	string HttpMethod,
+	string HttpMethodUppercase,
 	string ReturnType,
 	string? UnwrappedReturnType,
 	bool EnumerableReturnType,

--- a/TypeContractor/TypeScript/ApiClientWriter.cs
+++ b/TypeContractor/TypeScript/ApiClientWriter.cs
@@ -1,4 +1,5 @@
 using HandlebarsDotNet;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using TypeContractor.Helpers;
@@ -13,11 +14,11 @@ public partial class ApiClientWriter(string outputPath, string? relativeRoot)
 	private static readonly Encoding _utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 	private static readonly Dictionary<EndpointMethod, string> _httpMethods = new()
 	{
-		{ EndpointMethod.GET, "get" },
-		{ EndpointMethod.POST, "post" },
-		{ EndpointMethod.PUT, "put" },
-		{ EndpointMethod.PATCH, "patch" },
-		{ EndpointMethod.DELETE, "delete" },
+		{ EndpointMethod.GET, "GET" },
+		{ EndpointMethod.POST, "POST" },
+		{ EndpointMethod.PUT, "PUT" },
+		{ EndpointMethod.PATCH, "PATCH" },
+		{ EndpointMethod.DELETE, "DELETE" },
 	};
 
 	[GeneratedRegex(@"([^\$])\{([A-Za-z0-9]+)\}")]
@@ -116,6 +117,7 @@ public partial class ApiClientWriter(string outputPath, string? relativeRoot)
 				endpoint.Name,
 				endpoint.Obsolete is not null,
 				endpoint.Obsolete?.Reason ?? "",
+				method.ToLower(CultureInfo.InvariantCulture),
 				method,
 				returnType,
 				endpoint.UnwrappedReturnType?.Name,


### PR DESCRIPTION
Fixes #149